### PR TITLE
fix: avoid mutable default arguments in function signatures

### DIFF
--- a/count_tokens/count.py
+++ b/count_tokens/count.py
@@ -107,7 +107,7 @@ def count_tokens_in_large_file(
 
 def count_tokens_in_directory(
     directory_path: str,
-    file_patterns: List[str] = ["*.txt", "*.py", "*.md"],
+    file_patterns: List[str] = None,
     recursive: bool = False,
     encoding_name: str = "cl100k_base",
     use_streaming: bool = False,
@@ -120,7 +120,7 @@ def count_tokens_in_directory(
 
     Args:
         directory_path: Path to directory to scan
-        file_patterns: List of glob patterns to match files
+        file_patterns: List of glob patterns to match files (default: ["*.txt", "*.py", "*.md"])
         recursive: Whether to search subdirectories
         encoding_name: The name of the encoding to use
         use_streaming: Whether to use streaming for large files
@@ -132,6 +132,8 @@ def count_tokens_in_directory(
     Returns:
         Dict mapping filenames to token counts
     """
+    if file_patterns is None:
+        file_patterns = ["*.txt", "*.py", "*.md"]
     results = {}
     base_path = pathlib.Path(directory_path)
 
@@ -172,7 +174,7 @@ def count(
     file: str = None, 
     directory: str = None,
     encoding: str = "cl100k_base",
-    file_patterns: List[str] = ["*.txt", "*.py", "*.md"],
+    file_patterns: List[str] = None,
     recursive: bool = False,
     use_streaming: bool = False,
     chunk_size: int = 1024*1024,
@@ -188,7 +190,7 @@ def count(
         file: File path to count (optional)
         directory: Directory path to count (optional)
         encoding: Encoding to use
-        file_patterns: List of glob patterns when using directory mode
+        file_patterns: List of glob patterns when using directory mode (default: ["*.txt", "*.py", "*.md"])
         recursive: Whether to search subdirectories
         use_streaming: Whether to use streaming for large files
         chunk_size: Size of chunks to read in bytes (for streaming)
@@ -200,6 +202,8 @@ def count(
     Returns:
         Token count or dictionary of counts for directory mode
     """
+    if file_patterns is None:
+        file_patterns = ["*.txt", "*.py", "*.md"]
     result = None
     
     if text is not None:

--- a/tests/test_count.py
+++ b/tests/test_count.py
@@ -267,6 +267,23 @@ class TestCountTokensInDirectory:
         # When recursive=True, it should use ** pattern for depth
         mock_glob.assert_called_once_with("**/*.txt")
 
+    @patch("pathlib.Path.glob")
+    @patch("count_tokens.count.count_tokens_in_file")
+    def test_count_tokens_in_directory_default_patterns(self, mock_count_file, mock_glob):
+        """Test that default file patterns (*.txt, *.py, *.md) are used when None."""
+        mock_glob.return_value = []
+        mock_count_file.return_value = 100
+
+        # Call without file_patterns (uses default None -> ["*.txt", "*.py", "*.md"])
+        count_tokens_in_directory("/test")
+
+        # Verify glob was called with all three default patterns
+        glob_calls = [call[0][0] for call in mock_glob.call_args_list]
+        assert "*.txt" in glob_calls
+        assert "*.py" in glob_calls
+        assert "*.md" in glob_calls
+        assert len(glob_calls) == 3
+
 
 class TestCountFunction:
     def test_count_text_mode(self):
@@ -306,6 +323,18 @@ class TestCountFunction:
 
         assert result == mock_results
         mock_count_dir.assert_called_once()
+
+    @patch("count_tokens.count.count_tokens_in_directory")
+    def test_count_directory_mode_default_patterns(self, mock_count_dir):
+        """Test that count() passes default file patterns when None."""
+        mock_count_dir.return_value = {}
+
+        # Call without file_patterns (uses default None -> ["*.txt", "*.py", "*.md"])
+        count(directory="/test")
+
+        # Verify count_tokens_in_directory was called with the default patterns
+        call_kwargs = mock_count_dir.call_args[1]
+        assert call_kwargs["file_patterns"] == ["*.txt", "*.py", "*.md"]
 
     def test_count_no_input_provided(self):
         """Test the count function with no input provided."""


### PR DESCRIPTION
Replace mutable list defaults with None and initialize inside functions. Using mutable default arguments (lists) can lead to unexpected behavior if the default is modified, as the same list object is shared across calls.

Affected functions:
- count_tokens_in_directory()
- count()

Added tests to verify default patterns are correctly applied.