### PR TITLE
fix: properly escape special characters in CSV output

### DIFF
--- a/count_tokens/count.py
+++ b/count_tokens/count.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python3
 import argparse
-import pathlib
-import os
-import json
 import csv
+import io
+import json
+import pathlib
 from typing import Dict, List, Union
 
 import tiktoken
@@ -264,11 +264,12 @@ def _format_output(results, output_format="text"):
         return json.dumps(results, indent=2)
     elif output_format == "csv":
         if isinstance(results, dict):
-            output = []
-            output.append("file,tokens")
+            output = io.StringIO(newline='')
+            writer = csv.writer(output, lineterminator='\n')
+            writer.writerow(["file", "tokens"])
             for file_path, count in results.items():
-                output.append(f"{file_path},{count}")
-            return "\n".join(output)
+                writer.writerow([file_path, count])
+            return output.getvalue().rstrip('\n')
         return f"tokens\n{results}"
     else:  # text format (default)
         if isinstance(results, dict):

--- a/tests/test_count.py
+++ b/tests/test_count.py
@@ -392,6 +392,23 @@ class TestFormatOutput:
         assert "/test/file1.txt,100" in lines
         assert "/test/file2.txt,200" in lines
 
+    def test_format_output_csv_with_special_characters(self):
+        """Test CSV formatting properly escapes file paths with special characters."""
+        data = {
+            "/test/file,with,commas.txt": 100,
+            '/test/file "with" quotes.txt': 200,
+            "/test/normal.txt": 300,
+        }
+
+        result = _format_output(data, "csv")
+        lines = result.strip().split("\n")
+
+        assert lines[0] == "file,tokens"
+        # Paths with commas or quotes should be properly escaped/quoted
+        assert '"/test/file,with,commas.txt",100' in lines
+        assert '"/test/file ""with"" quotes.txt",200' in lines
+        assert "/test/normal.txt,300" in lines
+
     def test_format_output_text_with_errors(self):
         """Test formatting text output with error messages."""
         data = {


### PR DESCRIPTION
Use the csv module to properly escape file paths that contain commas, quotes, or other special characters. Previously, paths like '/test/file,with,commas.txt' would produce malformed CSV output.

Also cleaned up imports (removed unused 'os', sorted alphabetically, added 'io' for StringIO).